### PR TITLE
Support unet model

### DIFF
--- a/_doc/examples/plot_export_tiny_phi2.py
+++ b/_doc/examples/plot_export_tiny_phi2.py
@@ -89,7 +89,6 @@ print(f"expected: {string_type(expected, with_shape=True, with_min_max=True)}")
 
 
 with torch_export_patches(patch_transformers=True):
-
     # Two unnecessary steps but useful in case of an error
     # We check the cache is registered.
     assert is_cache_dynamic_registered()

--- a/_unittests/ut_export/test_shape_helper.py
+++ b/_unittests/ut_export/test_shape_helper.py
@@ -16,7 +16,6 @@ from onnx_diagnostic.torch_export_patches import torch_export_patches
 
 
 class TestShapeHelper(ExtTestCase):
-
     @requires_transformers("4.52")
     @requires_torch("2.7.99")
     def test_all_dynamic_shape_from_cache(self):

--- a/_unittests/ut_helpers/test_onnx_helper.py
+++ b/_unittests/ut_helpers/test_onnx_helper.py
@@ -26,7 +26,6 @@ TINT64 = TensorProto.INT64
 
 
 class TestOnnxHelper(ExtTestCase):
-
     def _get_model(self):
         model = oh.make_model(
             oh.make_graph(

--- a/_unittests/ut_helpers/test_ort_session.py
+++ b/_unittests/ut_helpers/test_ort_session.py
@@ -24,7 +24,6 @@ TFLOAT = onnx.TensorProto.FLOAT
 
 
 class TestOrtSession(ExtTestCase):
-
     @classmethod
     def _range(cls, *shape, bias: Optional[float] = None):
         n = np.prod(shape)

--- a/_unittests/ut_helpers/test_ort_session_tinyllm.py
+++ b/_unittests/ut_helpers/test_ort_session_tinyllm.py
@@ -19,7 +19,6 @@ from onnx_diagnostic.helpers.onnx_helper import np_dtype_to_tensor_dtype
 
 
 class TestOrtSessionTinyLLM(ExtTestCase):
-
     def test_ort_value(self):
         val = np.array([30, 31, 32], dtype=np.int64)
         ort = ORTC.OrtValue.ortvalue_from_numpy_with_onnx_type(val, onnx.TensorProto.INT64)

--- a/_unittests/ut_helpers/test_torch_helper.py
+++ b/_unittests/ut_helpers/test_torch_helper.py
@@ -32,7 +32,6 @@ TFLOAT = onnx.TensorProto.FLOAT
 
 
 class TestTorchTestHelper(ExtTestCase):
-
     def test_is_torchdynamo_exporting(self):
         self.assertFalse(is_torchdynamo_exporting())
 

--- a/_unittests/ut_reference/test_onnxruntime_evaluator.py
+++ b/_unittests/ut_reference/test_onnxruntime_evaluator.py
@@ -23,7 +23,6 @@ TFLOAT = onnx.TensorProto.FLOAT
 
 class TestOnnxruntimeEvaluator(ExtTestCase):
     def test_ort_eval_scan_cdist_add(self):
-
         def dist(unused: torch.Tensor, x: torch.Tensor, samex: torch.Tensor):
             sub = samex - x.reshape((1, -1))
             sq = sub * sub

--- a/_unittests/ut_torch_export_patches/test_dynamic_class.py
+++ b/_unittests/ut_torch_export_patches/test_dynamic_class.py
@@ -227,7 +227,6 @@ class TestOnnxExportErrors(ExtTestCase):
 
     @ignore_warnings(UserWarning)
     def test_export_dynamic_cache_cat(self):
-
         class ModelDynamicCache(torch.nn.Module):
             def forward(self, x, dc):
                 y = (

--- a/_unittests/ut_torch_export_patches/test_patch_expressions.py
+++ b/_unittests/ut_torch_export_patches/test_patch_expressions.py
@@ -11,7 +11,6 @@ from onnx_diagnostic.helpers.torch_helper import fake_torchdynamo_exporting
 
 
 class TestOnnxExportErrors(ExtTestCase):
-
     @classmethod
     def setUp(cls):
         register_patched_expressions()

--- a/_unittests/ut_torch_export_patches/test_patch_loops.py
+++ b/_unittests/ut_torch_export_patches/test_patch_loops.py
@@ -14,7 +14,6 @@ from onnx_diagnostic.torch_export_patches.patch_expressions import (
 
 
 class TestOnnxExportErrors(ExtTestCase):
-
     def test_patched_expressions(self):
         res = list(_iterate_patched_expressions())
         names = {_[0] for _ in res}
@@ -22,7 +21,6 @@ class TestOnnxExportErrors(ExtTestCase):
 
     @requires_torch("2.8")
     def test_filter_position_ids(self):
-
         def filter_position_ids(
             patch_attention_mask: torch.Tensor,
             position_ids: torch.Tensor,
@@ -57,7 +55,6 @@ class TestOnnxExportErrors(ExtTestCase):
             boundaries: torch.Tensor,
             num_patches_per_side: int,
         ):
-
             def body(p_attn_mask, position_ids_row):
                 h_len = torch.tensor(1) / p_attn_mask[:, 0].sum()
                 w_len = torch.tensor(1) / p_attn_mask[0].sum()

--- a/_unittests/ut_torch_export_patches/test_patch_module.py
+++ b/_unittests/ut_torch_export_patches/test_patch_module.py
@@ -48,7 +48,6 @@ class TestPatchModule(ExtTestCase):
         ), f"Missing parent in {ast.dump(tree, indent=2)}"
 
     def test_rewrite_test_in_forward_return1(self):
-
         class Model(torch.nn.Module):
             def forward(self, x, y):
                 if x.sum() > 0:
@@ -75,7 +74,6 @@ class TestPatchModule(ExtTestCase):
 
     @hide_stdout()
     def test_rewrite_test_in_forward_return2(self):
-
         class Model(torch.nn.Module):
             def forward(self, x, y):
                 if x.sum() > 0:
@@ -101,7 +99,6 @@ class TestPatchModule(ExtTestCase):
         self.assertEqualAny(expected_, ep.module()(-x, y))
 
     def test_rewrite_test_in_forward_assign1(self):
-
         class Model(torch.nn.Module):
             def forward(self, x, y):
                 if x.sum() > 0:
@@ -128,7 +125,6 @@ class TestPatchModule(ExtTestCase):
         self.assertEqualArray(expected_, ep.module()(-x, y))
 
     def test_rewrite_test_in_forward_assign2(self):
-
         class Model(torch.nn.Module):
             def forward(self, x, y):
                 if x.sum() > 0:
@@ -155,10 +151,8 @@ class TestPatchModule(ExtTestCase):
         self.assertEqualAny(expected_, ep.module()(-x, y))
 
     def test_check_syntax_assign_noelse(self):
-
         class Model(torch.nn.Module):
             def forward(self, x, y):
-
                 def branch_cond_then_1(x):
                     x = torch.abs(x) + 1
                     return x
@@ -179,7 +173,6 @@ class TestPatchModule(ExtTestCase):
         self.assertEqualAny(expected_, ep.module()(-x, y))
 
     def test_rewrite_test_in_forward_assign_noelse(self):
-
         class Model(torch.nn.Module):
             def forward(self, x, y):
                 if x.sum() > 0:
@@ -204,7 +197,6 @@ class TestPatchModule(ExtTestCase):
         self.assertEqualAny(expected_, ep.module()(-x, y))
 
     def test_rewrite_test_in_forward_return_noelse(self):
-
         class Model(torch.nn.Module):
             def forward(self, x, y):
                 if x.sum() > 0:
@@ -216,7 +208,6 @@ class TestPatchModule(ExtTestCase):
         )
 
     def test_rewrite_test_in_forward_assign2_in_2(self):
-
         class Model(torch.nn.Module):
             def forward(self, x, y):
                 if x.sum() > 0:
@@ -245,7 +236,6 @@ class TestPatchModule(ExtTestCase):
         self.assertEqualAny(expected_, ep.module()(-x, y))
 
     def test_rewrite_test_in_forward_assign2_in_3(self):
-
         class Model(torch.nn.Module):
             def forward(self, x, y):
                 if x.sum() > 0:
@@ -277,13 +267,11 @@ class TestPatchModule(ExtTestCase):
         self.assertEqualAny(expected_, ep.module()(-x, y))
 
     def test_assign_nested_check(self):
-
         torch_cond = torch.cond
 
         class Model(torch.nn.Module):
             def forward(self, x, y):
                 def torch_cond_then_3(y, x):
-
                     def torch_cond_then_1(y, x):
                         w = x + y
                         z = x - y
@@ -301,7 +289,6 @@ class TestPatchModule(ExtTestCase):
                     return (w, z)
 
                 def torch_cond_else_3(y, x):
-
                     def torch_cond_then_2(y):
                         u = y + 1
                         return u
@@ -322,7 +309,6 @@ class TestPatchModule(ExtTestCase):
         Model()(x, y)
 
     def test_rewrite_test_in_forward_assign_nested(self):
-
         class Model(torch.nn.Module):
             def forward(self, x, y):
                 if x.sum() > 0:
@@ -371,7 +357,6 @@ class TestPatchModule(ExtTestCase):
         self.assertEqualAny(expected_1, ep.module()(-x, -y))
 
     def test_rewrite_test_in_forward_none(self):
-
         class Model(torch.nn.Module):
             def forward(self, x, y):
                 if x is None:
@@ -513,7 +498,6 @@ class TestPatchModule(ExtTestCase):
 
     @requires_torch("2.8")
     def test_rewrite_loop(self):
-
         class Model(torch.nn.Module):
             def forward(self, x, y):
                 z = torch.empty((x.shape[0], y.shape[0]))

--- a/_unittests/ut_torch_models/test_hghub_api.py
+++ b/_unittests/ut_torch_models/test_hghub_api.py
@@ -27,7 +27,6 @@ from onnx_diagnostic.torch_models.hghub.hub_data import (
 
 
 class TestHuggingFaceHubApi(ExtTestCase):
-
     @requires_transformers("4.50")  # we limit to some versions of the CI
     @requires_torch("2.7")
     @ignore_errors(OSError)  # connectivity issues

--- a/_unittests/ut_torch_models/test_hghub_mode_rewrite.py
+++ b/_unittests/ut_torch_models/test_hghub_mode_rewrite.py
@@ -13,7 +13,6 @@ from onnx_diagnostic.torch_export_patches.patch_inputs import use_dyn_not_str
 
 
 class TestHuggingFaceHubModelRewrite(ExtTestCase):
-
     def test_code_needing_rewriting(self):
         self.assertEqual(2, len(code_needing_rewriting("BartForConditionalGeneration")))
 

--- a/_unittests/ut_torch_models/test_tiny_llms_bypassed.py
+++ b/_unittests/ut_torch_models/test_tiny_llms_bypassed.py
@@ -28,7 +28,6 @@ class TestTinyLlmBypassed(ExtTestCase):
         with torch_export_patches(
             patch_torch=False, patch_transformers=True, catch_constraints=False, verbose=10
         ) as modificator:
-
             for k in patched_DynamicCache._PATCHES_:
                 self.assertEqual(getattr(patched_DynamicCache, k), getattr(DynamicCache, k))
 

--- a/_unittests/ut_torch_onnx/test_sbs.py
+++ b/_unittests/ut_torch_onnx/test_sbs.py
@@ -15,7 +15,6 @@ except ImportError:
 
 
 class TestSideBySide(ExtTestCase):
-
     @hide_stdout()
     @unittest.skipIf(to_onnx is None, "to_onnx not installed")
     @ignore_errors(OSError)  # connectivity issues

--- a/_unittests/ut_xrun_doc/test_doc_doc.py
+++ b/_unittests/ut_xrun_doc/test_doc_doc.py
@@ -4,7 +4,6 @@ from onnx_diagnostic.doc import reset_torch_transformers
 
 
 class TestDocDoc(ExtTestCase):
-
     def test_reset(self):
         reset_torch_transformers(None, None)
 

--- a/onnx_diagnostic/export/dynamic_shapes.py
+++ b/onnx_diagnostic/export/dynamic_shapes.py
@@ -341,7 +341,7 @@ class CoupleInputsDynamicShapes:
                     if any(v is not None for v in value)
                     else None
                 )
-            assert type(inputs) is dict, f"Unexpected type for inputs {type(inputs)}"
+            assert isinstance(inputs, dict), f"Unexpected type for inputs {type(inputs)}"
             assert set(inputs) == set(ds), (
                 f"Keys mismatch between inputs {set(inputs)} and ds={set(ds)}, "
                 f"inputs={string_type(inputs, with_shape=True)}, ds={ds}"

--- a/onnx_diagnostic/helpers/config_helper.py
+++ b/onnx_diagnostic/helpers/config_helper.py
@@ -38,12 +38,12 @@ def update_config(config: Any, mkwargs: Dict[str, Any]):
                 setattr(config, k, v)
                 continue
             existing = getattr(config, k)
-            if type(existing) is dict:
+            if isinstance(existing, dict):
                 existing.update(v)
             else:
                 update_config(getattr(config, k), v)
             continue
-        if type(config) is dict:
+        if isinstance(config, dict):
             config[k] = v
         else:
             setattr(config, k, v)
@@ -76,7 +76,7 @@ def pick(config, name: str, default_value: Any) -> Any:
     """
     if not config:
         return default_value
-    if type(config) is dict:
+    if isinstance(config, dict):
         return config.get(name, default_value)
     return getattr(config, name, default_value)
 

--- a/onnx_diagnostic/helpers/helper.py
+++ b/onnx_diagnostic/helpers/helper.py
@@ -280,7 +280,7 @@ def string_type(
             print(f"[string_type] L:{type(obj)}")
         return f"{{...}}#{len(obj)}" if with_shape else "{...}"
     # dict
-    if isinstance(obj, dict) and type(obj) is dict:
+    if isinstance(obj, dict):
         if len(obj) == 0:
             if verbose:
                 print(f"[string_type] M:{type(obj)}")

--- a/onnx_diagnostic/helpers/mini_onnx_builder.py
+++ b/onnx_diagnostic/helpers/mini_onnx_builder.py
@@ -498,7 +498,7 @@ def _unflatten(
             for k, v in res:
                 setattr(r, k, v)
             return r
-        if ty is dict:
+        if isinstance(res, dict):
             d = {}
             for k, v in res:
                 if k.startswith("((") and k.endswith("))"):

--- a/onnx_diagnostic/helpers/ort_session.py
+++ b/onnx_diagnostic/helpers/ort_session.py
@@ -19,7 +19,6 @@ DEVICES = {-1: ORTC.OrtDevice(ORTC.OrtDevice.cpu(), ORTC.OrtDevice.default_memor
 
 
 class _InferenceSession:
-
     @classmethod
     def has_onnxruntime_training(cls):
         """Tells if onnxruntime_training is installed."""

--- a/onnx_diagnostic/helpers/rt_helper.py
+++ b/onnx_diagnostic/helpers/rt_helper.py
@@ -79,7 +79,6 @@ def make_feeds(
     if len(names) < len(flat) and (
         isinstance(proto, onnx.ModelProto) or hasattr(proto, "get_inputs")
     ):
-
         typed_names = (
             [(i.name, i.type.tensor_type.elem_type) for i in proto.graph.input]
             if isinstance(proto, onnx.ModelProto)

--- a/onnx_diagnostic/helpers/torch_helper.py
+++ b/onnx_diagnostic/helpers/torch_helper.py
@@ -717,7 +717,7 @@ def to_any(value: Any, to_value: Union[torch.dtype, torch.device, str]) -> Any:
         return tuple(to_any(t, to_value) for t in value)
     if isinstance(value, set):
         return {to_any(t, to_value) for t in value}
-    if type(value) is dict:
+    if isinstance(value, dict):
         return {k: to_any(t, to_value) for k, t in value.items()}
     if value.__class__.__name__ == "DynamicCache":
         return make_dynamic_cache(

--- a/onnx_diagnostic/helpers/torch_helper.py
+++ b/onnx_diagnostic/helpers/torch_helper.py
@@ -526,7 +526,6 @@ def dummy_llm(
             return word_emb + word_pe
 
     class AttentionBlock(torch.nn.Module):
-
         def __init__(self, embedding_dim: int = 16, context_size: int = 256):
             super().__init__()
             self.query = torch.nn.Linear(embedding_dim, embedding_dim, bias=False)
@@ -555,7 +554,6 @@ def dummy_llm(
             return out
 
     class MultiAttentionBlock(torch.nn.Module):
-
         def __init__(
             self, embedding_dim: int = 16, num_heads: int = 2, context_size: int = 256
         ):
@@ -573,7 +571,6 @@ def dummy_llm(
             return x
 
     class FeedForward(torch.nn.Module):
-
         def __init__(self, embedding_dim: int = 16, ff_dim: int = 128):
             super().__init__()
             self.linear_1 = torch.nn.Linear(embedding_dim, ff_dim)
@@ -587,7 +584,6 @@ def dummy_llm(
             return x
 
     class DecoderLayer(torch.nn.Module):
-
         def __init__(
             self,
             embedding_dim: int = 16,
@@ -613,7 +609,6 @@ def dummy_llm(
             return ff
 
     class LLM(torch.nn.Module):
-
         def __init__(
             self,
             vocab_size: int = 1024,

--- a/onnx_diagnostic/reference/ops/op_scan.py
+++ b/onnx_diagnostic/reference/ops/op_scan.py
@@ -3,7 +3,6 @@ from onnx.reference.ops.op_scan import Scan as _Scan
 
 
 class Scan(_Scan):
-
     def need_context(self) -> bool:
         """Tells the runtime if this node needs the context
         (all the results produced so far) as it may silently access

--- a/onnx_diagnostic/torch_export_patches/eval/model_cases.py
+++ b/onnx_diagnostic/torch_export_patches/eval/model_cases.py
@@ -358,7 +358,6 @@ class ControlFlowCondIdentity_153832(torch.nn.Module):
     """
 
     def forward(self, x, y):
-
         def branch_cond_then_1(x):
             x = torch.abs(x) + 1
             return x
@@ -789,7 +788,6 @@ class TypeBFloat16(torch.nn.Module):
 
 
 class CropLastDimensionWithTensorShape(torch.nn.Module):
-
     def forward(self, x, y):
         return x[..., : y.shape[0]]
 

--- a/onnx_diagnostic/torch_export_patches/patch_module_helper.py
+++ b/onnx_diagnostic/torch_export_patches/patch_module_helper.py
@@ -22,7 +22,6 @@ def ast_or_into_bitor(node: "ast.Node") -> "ast.Node":
 
 @functools.lru_cache
 def _rewrite_forward_clamp_float16() -> Dict[str, List[type]]:
-
     import transformers
 
     _known = {

--- a/onnx_diagnostic/torch_export_patches/patches/patch_torch.py
+++ b/onnx_diagnostic/torch_export_patches/patches/patch_torch.py
@@ -166,7 +166,6 @@ def patched__broadcast_shapes(*_shapes):
 
 
 class patched_ShapeEnv:
-
     def _check_frozen(
         self, expr: "sympy.Basic", concrete_val: "sympy.Basic"  # noqa: F821
     ) -> None:

--- a/onnx_diagnostic/torch_export_patches/patches/patch_transformers.py
+++ b/onnx_diagnostic/torch_export_patches/patches/patch_transformers.py
@@ -1103,9 +1103,11 @@ class patched_IdeficsAttention(torch.nn.Module):
                 .transpose(1, 2)
             )
         else:
-            _, kv_len, _ = (
-                key_value_states.size()
-            )  # Note that, in this case, `kv_len` == `kv_seq_len`
+            (
+                _,
+                kv_len,
+                _,
+            ) = key_value_states.size()  # Note that, in this case, `kv_len` == `kv_seq_len`
             key_states = (
                 self.k_proj(key_value_states)
                 .view(bsz, kv_len, self.num_heads, self.head_dim)
@@ -1127,10 +1129,11 @@ class patched_IdeficsAttention(torch.nn.Module):
                 torch.tensor(q_len, dtype=torch.int64),
             )
             cos, sin = self.rotary_emb(value_states, seq_len=rotary_length)
-            query_states, key_states = (
-                transformers.models.idefics.modeling_idefics.apply_rotary_pos_emb(
-                    query_states, key_states, cos, sin, position_ids
-                )
+            (
+                query_states,
+                key_states,
+            ) = transformers.models.idefics.modeling_idefics.apply_rotary_pos_emb(
+                query_states, key_states, cos, sin, position_ids
             )
         # [bsz, nh, t, hd]
 

--- a/onnx_diagnostic/torch_export_patches/serialization/transformers_impl.py
+++ b/onnx_diagnostic/torch_export_patches/serialization/transformers_impl.py
@@ -67,7 +67,9 @@ def unflatten_mamba_cache(
     return cache
 
 
-def flatten_with_keys_mamba_cache(cache: MambaCache) -> Tuple[
+def flatten_with_keys_mamba_cache(
+    cache: MambaCache,
+) -> Tuple[
     List[Tuple[torch.utils._pytree.KeyEntry, Any]],
     torch.utils._pytree.Context,
 ]:
@@ -224,7 +226,9 @@ def flatten_encoder_decoder_cache(
     return torch.utils._pytree._dict_flatten(dictionary)
 
 
-def flatten_with_keys_encoder_decoder_cache(ec_cache: EncoderDecoderCache) -> Tuple[
+def flatten_with_keys_encoder_decoder_cache(
+    ec_cache: EncoderDecoderCache,
+) -> Tuple[
     List[Tuple[torch.utils._pytree.KeyEntry, Any]],
     torch.utils._pytree.Context,
 ]:

--- a/onnx_diagnostic/torch_models/hghub/hub_api.py
+++ b/onnx_diagnostic/torch_models/hghub/hub_api.py
@@ -10,7 +10,6 @@ from huggingface_hub import HfApi, model_info, hf_hub_download, list_repo_files
 from ...helpers.config_helper import update_config
 from . import hub_data_cached_configs
 from .hub_data import __date__, __data_tasks__, load_architecture_task, __data_arch_values__
-import diffusers
 
 
 @functools.cache
@@ -127,6 +126,8 @@ def get_pretrained_config(
     except ValueError:
         # The model might be from diffusers, not transformers.
         try:
+            import diffusers
+
             pipe = diffusers.DiffusionPipeline.from_pretrained(
                 model_id, trust_remote_code=trust_remote_code, **kwargs
             )

--- a/onnx_diagnostic/torch_models/hghub/model_inputs.py
+++ b/onnx_diagnostic/torch_models/hghub/model_inputs.py
@@ -119,9 +119,9 @@ def get_untrained_model_with_inputs(
 
     # model kwagrs
     if dynamic_rope is not None:
-        assert type(config) is not dict, (
-            f"Unable to set dynamic_rope if the configuration is a dictionary\n{config}"
-        )
+        assert (
+            type(config) is not dict
+        ), f"Unable to set dynamic_rope if the configuration is a dictionary\n{config}"
         assert hasattr(config, "rope_scaling"), f"Missing 'rope_scaling' in\n{config}"
         config.rope_scaling = (
             {"rope_type": "dynamic", "factor": 10.0} if dynamic_rope else None

--- a/onnx_diagnostic/torch_models/hghub/model_inputs.py
+++ b/onnx_diagnostic/torch_models/hghub/model_inputs.py
@@ -113,6 +113,7 @@ def get_untrained_model_with_inputs(
         print(f"[get_untrained_model_with_inputs] architectures={archs!r}")
         print(f"[get_untrained_model_with_inputs] cls={config.__class__.__name__!r}")
     if task is None:
+        assert archs is not None
         task = task_from_arch(archs[0], model_id=model_id, subfolder=subfolder)
     if verbose:
         print(f"[get_untrained_model_with_inputs] task={task!r}")

--- a/onnx_diagnostic/torch_models/validate.py
+++ b/onnx_diagnostic/torch_models/validate.py
@@ -252,7 +252,6 @@ def shrink_config(cfg: Dict[str, Any]) -> Dict[str, Any]:
     """Shrinks the configuration before it gets added to the information to log."""
     new_cfg = {}
     for k, v in cfg.items():
-
         new_cfg[k] = (
             v
             if (not isinstance(v, (list, tuple, set, dict)) or len(v) < 50)
@@ -827,7 +826,6 @@ def _validate_do_run_model(
 
 
 def _validate_do_run_exported_program(data, summary, verbose, quiet):
-
     # We run a second time the model to check the patch did not
     # introduce any discrepancies
     if verbose:

--- a/onnx_diagnostic/torch_models/validate.py
+++ b/onnx_diagnostic/torch_models/validate.py
@@ -576,7 +576,7 @@ def validate_model(
     summary["model_config"] = str(
         shrink_config(
             data["configuration"]
-            if type(data["configuration"]) is dict
+            if isinstance(data["configuration"], dict)
             else data["configuration"].to_dict()
         )
     ).replace(" ", "")


### PR DESCRIPTION
Previous to this PR, `text-to-image` models did not work because they are usually from diffusers package, which they are not like transformers models. Transformers models only have one configuration, and the whole model is trained together even if it's multi-modal model. 

However, in diffusers models, they usually have 4 configurations for 4 independent models: text encoder (takes text input), unet (backbone: denoising), vae (Maps between pixel space ↔ latent space (compression)), and scheduler (Controls the denoising process over time steps). Unfortunately, due to the current code design, we can't test a full diffuser model without a big refactor, since the code is written to run LLM. We will need more follow-ups to test a full model.

This PR enables us to test unet model only.