### PR TITLE
Delete hidden_size and num_attention_heads modification in a config

### DIFF
--- a/onnx_diagnostic/tasks/text_generation.py
+++ b/onnx_diagnostic/tasks/text_generation.py
@@ -34,6 +34,9 @@ def reduce_model_config(config: Any) -> Dict[str, Any]:
         )
     else:
         kwargs = dict(
+            head_dim=getattr(
+                config, "head_dim", config.hidden_size // config.num_attention_heads
+            ),
             num_hidden_layers=min(config.num_hidden_layers, 2),
             num_key_value_heads=(
                 config.num_key_value_heads


### PR DESCRIPTION
Previous to this PR, the config is modified to smaller (not significant smaller) to speed up the model run/export on the benchmark. However, there is a hard requirements on LLMs that "`embed_dim` must be divisible by num_heads" (e.g.: https://github.com/huggingface/transformers/blob/main/src/transformers/models/gpt2/modeling_gpt2.py#L175-L178). 

This PR deletes the lines of code that modifies those attributes, because (1) reduce num_layers should be enough for speedy model run/export, (2) conditionally adjust these attributes might affect model performance (deviate from its design)