### PR TITLE
Setup prompt-processsing and token-generation testing in text generation tasks

### DIFF
--- a/_unittests/ut_tasks/test_tasks.py
+++ b/_unittests/ut_tasks/test_tasks.py
@@ -43,7 +43,9 @@ class TestTasks(ExtTestCase):
         model, inputs, ds = data["model"], data["inputs"], data["dynamic_shapes"]
         model(**inputs)
         model(**data["inputs2"])
-        with torch_export_patches(patch_transformers=True, verbose=10):
+        with torch_export_patches(
+            patch_transformers=True, verbose=10
+        ), torch.fx.experimental._config.patch(backed_size_oblivious=True):
             torch.export.export(
                 model, (), kwargs=inputs, dynamic_shapes=use_dyn_not_str(ds), strict=False
             )

--- a/_unittests/ut_tasks/test_tasks_text_generation.py
+++ b/_unittests/ut_tasks/test_tasks_text_generation.py
@@ -1,0 +1,39 @@
+import unittest
+from onnx_diagnostic.ext_test_case import (
+    ExtTestCase,
+    hide_stdout,
+    requires_transformers,
+    requires_torch,
+)
+from onnx_diagnostic.torch_models.validate import validate_model
+
+
+class TestTasksMaskGeneration(ExtTestCase):
+    @hide_stdout()
+    @requires_transformers("4.53")
+    @requires_torch("2.7.99")
+    def test_text_generation(self):
+        mid = "microsoft/phi-2"
+        summary, data = validate_model(
+            mid,
+            do_run=True,
+            verbose=10,
+            exporter="onnx-dynamo",
+            dump_folder="dump_test/microsoft_phi-2",
+            inputs2=True,
+            patch=True,
+        )
+        self.assertIsInstance(summary, dict)
+        # token generation
+        self.assertLess(summary["disc_onnx_ort_run_abs"], 3e-2)
+        # prompt processing
+        self.assertLess(summary["disc_onnx_ort_run2_abs"], 3e-2)
+        # multi-turn conversation
+        self.assertLess(summary["disc_onnx_ort_run3_abs"], 3e-2)
+        self.assertIsInstance(data, dict)
+        onnx_filename = data["onnx_filename"]
+        self.assertExists(onnx_filename)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/_unittests/ut_torch_export_patches/test_dynamic_class.py
+++ b/_unittests/ut_torch_export_patches/test_dynamic_class.py
@@ -307,7 +307,9 @@ class TestOnnxExportErrors(ExtTestCase):
             str_inputs, string_type(inputs_copied, with_shape=True, with_min_max=True)
         )
 
-        with torch_export_patches(patch_transformers=True):
+        with torch_export_patches(
+            patch_transformers=True
+        ), torch.fx.experimental._config.patch(backed_size_oblivious=True):
             ep = torch.export.export(
                 model,
                 (),
@@ -346,7 +348,9 @@ class TestOnnxExportErrors(ExtTestCase):
             str_inputs, string_type(inputs_copied, with_shape=True, with_min_max=True)
         )
 
-        with torch_export_patches(patch_transformers=True, verbose=1):
+        with torch_export_patches(
+            patch_transformers=True, verbose=1
+        ), torch.fx.experimental._config.patch(backed_size_oblivious=True):
             if masking_utils is not None:
                 self.assertEqual(
                     masking_utils.ALL_MASK_ATTENTION_FUNCTIONS["sdpa"],

--- a/onnx_diagnostic/helpers/helper.py
+++ b/onnx_diagnostic/helpers/helper.py
@@ -1061,36 +1061,6 @@ def max_diff(
             print(f"[max_diff] to_tuple2: {string_type(expected)} ? {string_type(got)}")
         return max_diff(expected, got.to_tuple(), debug_info=_debug("to_tuple2"), **_dkws)
 
-        if isinstance(got, (list, tuple)):
-            if len(got) != 1:
-                if verbose >= 6:
-                    print(
-                        f"[max_diff] list,tuple,2: {string_type(expected)} "
-                        f"? {string_type(got)}"
-                    )
-                if verbose > 2:
-                    import torch
-
-                    print(
-                        f"[max_diff] (a) inf because len(expected)={len(expected)}!=1, "
-                        f"len(got)={len(got)}, level={level}, _index={_index}"
-                    )
-                    for i, (a, b) in enumerate(zip(expected, got)):
-                        if isinstance(a, torch.Tensor) and isinstance(b, torch.Tensor):
-                            print(
-                                f"    i={i} expected {a.dtype}:{a.shape}, "
-                                f"has {b.dtype}:{b.shape}, _index={_index}"
-                            )
-                        else:
-                            print(
-                                f"    i={i} a is {type(a)}, "
-                                f"b is {type(b)}, _index={_index}"
-                            )
-                return dict(abs=np.inf, rel=np.inf, sum=np.inf, n=np.inf, dnan=np.inf)
-            if verbose >= 6:
-                print(f"[max_diff] list,tuple,1: {string_type(expected)} ? {string_type(got)}")
-            return max_diff(expected, got[0], debug_info=_debug("lt1"), **_dkws)
-
     if isinstance(expected, (tuple, list)):
         if verbose >= 6:
             print(f"[max_diff] list,tuple,0: {string_type(expected)} ? {string_type(got)}")

--- a/onnx_diagnostic/tasks/text_generation.py
+++ b/onnx_diagnostic/tasks/text_generation.py
@@ -245,6 +245,7 @@ def get_inputs(
                 .to(torch.int64)
                 .expand((batch_size, -1)),
             )
+            # Caches are involved
             if past_sequence_length > 0:
                 inputs["past_key_values"] = make_cache(
                     [

--- a/onnx_diagnostic/tasks/text_generation.py
+++ b/onnx_diagnostic/tasks/text_generation.py
@@ -173,37 +173,34 @@ def get_inputs(
             # static
             shapes = {
                 "input_ids": {0: batch, 1: seq_length},
-                "attention_mask": {0: batch, 2: "sequence_length+past_sequence_length"},
-                "cache_position": {0: "sequence_length+past_sequence_length"},
+                "attention_mask": {0: batch, 2: "past_sequence_length"},
+                "cache_position": {0: "past_sequence_length"},
                 "past_key_values": [
-                    # [{0: batch, 2: past_seq_length} for _ in range(num_hidden_layers)],
-                    # [{0: batch, 2: past_seq_length} for _ in range(num_hidden_layers)],
+                    # past_sequence_length is now static
                     [{0: batch} for _ in range(num_hidden_layers)],
                     [{0: batch} for _ in range(num_hidden_layers)],
                 ],
             }
             inputs = dict(
                 input_ids=torch.randint(
-                    0, dummy_max_token_id, (batch_size, sequence_length)
+                    0, dummy_max_token_id, (batch_size, past_sequence_length)
                 ).to(torch.int64),
                 attention_mask=torch.ones(
                     (
                         batch_size,
                         num_key_value_heads,
-                        past_sequence_length + sequence_length,
+                        past_sequence_length,
                         head_dim,
                     )
                 ).to(torch.bool),
-                cache_position=torch.arange(past_sequence_length + sequence_length).to(
-                    torch.int64
-                ),
+                cache_position=torch.arange(past_sequence_length).to(torch.int64),
                 past_key_values=make_static_cache(
                     [
                         (
                             torch.randn(
                                 batch_size,
                                 num_key_value_heads,
-                                past_sequence_length + sequence_length,
+                                sequence_length + past_sequence_length,
                                 head_dim,
                             ),
                             torch.randn(
@@ -215,7 +212,7 @@ def get_inputs(
                         )
                         for i in range(num_hidden_layers)
                     ],
-                    max_cache_len=max(sequence_length + past_sequence_length, head_dim),
+                    max_cache_len=max(past_sequence_length, head_dim),
                 ),
             )
         else:

--- a/onnx_diagnostic/tasks/text_generation.py
+++ b/onnx_diagnostic/tasks/text_generation.py
@@ -230,8 +230,11 @@ def get_inputs(
                     0: batch,
                     1: seq_length,
                 },
+                "past_key_values": [
+                    [{0: batch, 2: past_seq_length} for _ in range(num_hidden_layers)],
+                    [{0: batch, 2: past_seq_length} for _ in range(num_hidden_layers)],
+                ],
             }
-
             inputs = dict(
                 input_ids=torch.randint(
                     0, dummy_max_token_id, (batch_size, sequence_length)
@@ -244,10 +247,7 @@ def get_inputs(
                 )
                 .to(torch.int64)
                 .expand((batch_size, -1)),
-            )
-            # Caches are involved
-            if past_sequence_length > 0:
-                inputs["past_key_values"] = make_cache(
+                past_key_values=make_cache(
                     [
                         (
                             torch.randn(
@@ -259,11 +259,10 @@ def get_inputs(
                         )
                         for i in range(num_hidden_layers)
                     ]
-                )
-                shapes["past_key_values"] = [
-                    [{0: batch, 2: past_seq_length} for _ in range(num_hidden_layers)],
-                    [{0: batch, 2: past_seq_length} for _ in range(num_hidden_layers)],
-                ]
+                ),
+            )
+        # NOTE: past_sequence_length can be 0 when testing prompt processing,
+        # which it becomes an empty tensor
         res = dict(inputs=inputs, dynamic_shapes=shapes)
     if add_second_input:
         # prompt processing (prefill) testing

--- a/onnx_diagnostic/tasks/text_generation.py
+++ b/onnx_diagnostic/tasks/text_generation.py
@@ -247,7 +247,7 @@ def get_inputs(
                 )
                 .to(torch.int64)
                 .expand((batch_size, -1)),
-                past_key_values=make_cache(
+                past_key_values=make_cache(  # type: ignore[operator]
                     [
                         (
                             torch.randn(

--- a/onnx_diagnostic/tasks/text_generation.py
+++ b/onnx_diagnostic/tasks/text_generation.py
@@ -221,7 +221,7 @@ def get_inputs(
                 "input_ids": {0: batch, 1: seq_length},
                 "attention_mask": {
                     0: batch,
-                    1: "cache+seq",  # past_seq_length + seq_length
+                    1: "past_seq_length+seq_length",  # past_seq_length + seq_length
                 },
                 "position_ids": {
                     0: batch,

--- a/onnx_diagnostic/tasks/text_generation.py
+++ b/onnx_diagnostic/tasks/text_generation.py
@@ -278,6 +278,24 @@ def get_inputs(
             add_second_input=0,
             **kwargs,
         )["inputs"]
+        # multi-turn conversation
+        # prompt-processing -> token-generation(loop output) ->
+        # prompt-processing from the loop output
+        res["inputs3"] = get_inputs(
+            model=model,
+            config=config,
+            dummy_max_token_id=dummy_max_token_id,
+            num_hidden_layers=num_hidden_layers,
+            batch_size=1,
+            past_sequence_length=32,
+            sequence_length=8,
+            dynamic_rope=dynamic_rope,
+            num_key_value_heads=num_key_value_heads,
+            head_dim=head_dim,
+            cls_cache=cls_cache,
+            add_second_input=0,
+            **kwargs,
+        )["inputs"]
     return res
 
 

--- a/onnx_diagnostic/torch_export_patches/patches/patch_transformers.py
+++ b/onnx_diagnostic/torch_export_patches/patches/patch_transformers.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from functools import wraps
 from typing import Callable, List, Optional, Tuple
 import packaging.version as pv
-from sklearn import logger
 import torch
 import transformers
 from transformers.modeling_attn_mask_utils import AttentionMaskConverter
@@ -1658,11 +1657,6 @@ if patch_modeling_utils:
         **kwargs,
     ) -> tuple[torch.Tensor, None]:
         """manual patch for function ```transformers.integrations.sdpa_attention.sdpa_attention_forward```."""  # noqa: E501
-        if kwargs.get("output_attentions", False) or kwargs.get("head_mask") is not None:
-            logger.warning_once(
-                "`sdpa` attention does not support `output_attentions=True` or `head_mask`."
-                " Please set your attention to `eager` if you want any of these features."
-            )
         sdpa_kwargs = {}
         if hasattr(module, "num_key_value_groups"):
             if not use_gqa_in_sdpa(attention_mask, key):

--- a/onnx_diagnostic/torch_export_patches/patches/patch_transformers.py
+++ b/onnx_diagnostic/torch_export_patches/patches/patch_transformers.py
@@ -1657,7 +1657,7 @@ if patch_modeling_utils:
         is_causal: Optional[bool] = None,
         **kwargs,
     ) -> tuple[torch.Tensor, None]:
-        """manual patch for function ```transformers.integrations.sdpa_attention.sdpa_attention_forward```."""
+        """manual patch for function ```transformers.integrations.sdpa_attention.sdpa_attention_forward```."""  # noqa: E501
         if kwargs.get("output_attentions", False) or kwargs.get("head_mask") is not None:
             logger.warning_once(
                 "`sdpa` attention does not support `output_attentions=True` or `head_mask`."
@@ -1674,18 +1674,18 @@ if patch_modeling_utils:
         if attention_mask is not None and attention_mask.ndim == 4:
             attention_mask = attention_mask[:, :, :, : key.shape[-2]]
 
-        # We dispatch to SDPA's Flash Attention or Efficient kernels via this `is_causal` if statement instead of an inline conditional assignment
-        # in SDPA to support both torch.compile's dynamic shapes and full graph options. An inline conditional prevents dynamic shapes from compiling.
-        # Note that it is important to check first for the shape, otherwise compile will fail with `argument 'is_causal' must be bool, not SymBool`
+        # We dispatch to SDPA's Flash Attention or Efficient kernels via this `is_causal` if statement instead of an inline conditional assignment  # noqa: E501
+        # in SDPA to support both torch.compile's dynamic shapes and full graph options. An inline conditional prevents dynamic shapes from compiling.  # noqa: E501
+        # Note that it is important to check first for the shape, otherwise compile will fail with `argument 'is_causal' must be bool, not SymBool`  # noqa: E501
         if is_causal is None:
-            # The last condition is for encoder (decoder) models which specify this by passing their own `is_causal` flag
-            # This is mainly due to those models having mixed implementations for encoder, decoder, and encoder-decoder attns
-            # is_causal = query.shape[2] > 1 and attention_mask is None and getattr(module, "is_causal", True)
+            # The last condition is for encoder (decoder) models which specify this by passing their own `is_causal` flag  # noqa: E501
+            # This is mainly due to those models having mixed implementations for encoder, decoder, and encoder-decoder attns  # noqa: E501
+            # is_causal = query.shape[2] > 1 and attention_mask is None and getattr(module, "is_causal", True)  # noqa: E501
             # NOTE: query.shape[2] == 1 or > 1 should have the same output for causal attention
             # so we simplify the condition to:
             is_causal = attention_mask is None and getattr(module, "is_causal", True)
 
-        # Shapes (e.g. query.shape[2]) are tensors during jit tracing, resulting in `is_causal` being a tensor.
+        # Shapes (e.g. query.shape[2]) are tensors during jit tracing, resulting in `is_causal` being a tensor.  # noqa: E501
         # We convert it to a bool for the SDPA kernel that only accepts bools.
         if torch.jit.is_tracing() and isinstance(is_causal, torch.Tensor):
             is_causal = is_causal.item()

--- a/onnx_diagnostic/torch_models/untrained/llm_tiny_llm.py
+++ b/onnx_diagnostic/torch_models/untrained/llm_tiny_llm.py
@@ -5,7 +5,7 @@ import transformers
 def get_tiny_llm(
     batch_size: int = 2,
     sequence_length: int = 30,
-    sequence_length2: int = 3,
+    past_sequence_length: int = 3,
     dynamic_rope: bool = False,
     use_static_cache: bool = False,
     **kwargs,
@@ -15,7 +15,7 @@ def get_tiny_llm(
 
     :param batch_size: batch size
     :param sequence_length: sequence length
-    :param sequence_length2: new sequence length
+    :param past_sequence_length: past sequence length
     :param dynamic_rope: use dynamic rope (see :class:`transformers.LlamaConfig`)
     :param use_static_cache: use StaticCache instead of DynamicCache
     :param kwargs: to overwrite the configuration, example ``num_hidden_layers=1``
@@ -62,7 +62,7 @@ def get_tiny_llm(
         num_hidden_layers=config["num_hidden_layers"],  # type: ignore[arg-type]
         batch_size=batch_size,
         sequence_length=sequence_length,
-        sequence_length2=sequence_length2,
+        past_sequence_length=past_sequence_length,
         dynamic_rope=dynamic_rope,
         num_key_value_heads=config["num_key_value_heads"],  # type: ignore[arg-type]
         cls_cache="StaticCache" if use_static_cache else "DynamicCache",

--- a/onnx_diagnostic/torch_models/validate.py
+++ b/onnx_diagnostic/torch_models/validate.py
@@ -521,6 +521,11 @@ def validate_model(
                 f.write(f"model_id: {model_id}\n------\n")
                 f.write(pprint.pformat(dump_info))
 
+    # modelbuilder needs different treatments sometimes, so
+    # we mark it for later usage.
+    # for example, it has different past_kv ordering than
+    # flattened CacheObject
+    data["exporter"] = exporter
     data["input_options"] = iop
     data["model_options"] = mop
     data["model_dump_folder"] = dump_folder

--- a/onnx_diagnostic/torch_models/validate.py
+++ b/onnx_diagnostic/torch_models/validate.py
@@ -493,30 +493,6 @@ def validate_model(
                 f.write(f"model_id: {model_id}\n------\n")
                 f.write(pprint.pformat(dump_info))
 
-    if exporter == "modelbuilder":
-        # Models used with ModelBuilder do not like batch size > 1.
-        # Let's change that.
-        for k in ["inputs", "inputs2"]:
-            if k not in data:
-                continue
-            if verbose:
-                print(f"[validate_model] set batch=1 for data[{k!r}]")
-                print(f"[validate_model] batch=1 === {string_type(data[k], with_shape=True)}")
-            cpl = CoupleInputsDynamicShapes(
-                tuple(), data[k], dynamic_shapes=data["dynamic_shapes"]
-            )
-            if patch_kwargs.get("patch", False):
-                with torch_export_patches(**patch_kwargs):  # type: ignore[arg-type]
-                    data[k] = cpl.change_dynamic_dimensions(
-                        desired_values=dict(batch=1), only_desired=True
-                    )
-            else:
-                data[k] = cpl.change_dynamic_dimensions(
-                    desired_values=dict(batch=1), only_desired=True
-                )
-            if verbose:
-                print(f"[validate_model] batch=1 --> {string_type(data[k], with_shape=True)}")
-
     data["input_options"] = iop
     data["model_options"] = mop
     data["model_dump_folder"] = dump_folder


### PR DESCRIPTION
Previous to this PR, in text-generation task, we are exporting and testing LLMs with **multi-turn conversation**, where the model runs "prompt processing" --> [for loop for "token generation"] --> using the for loop output for prompt processing again, and the whole run is restricted to have `batch_size=1` in GQA contrib op.

In this PR, we export LLMs with token generation setting, and test the model with both token generation and prompt processing scenario.

Cited @kunal-vaishnavi 

These are the general shapes:
* input_ids = (batch_size, sequence_length)
* attn_mask = (batch_size, past_sequence_length + sequence_length)
* pos_ids = (batch_size, sequence_length)
* past_key_values = (batch_size, num_key_value_heads, past_sequence_length, head_dim)
* present_key_values = (batch_size, num_key_value_heads, past_sequence_length + sequence_length, head_dim)

**Prompt processing (aka prefill):**
* input_ids = (batch_size, prompt_length)
* attn_mask = (batch_size, 0 + prompt_length) = (batch_size, prompt_length)
* pos_ids = (batch_size, prompt_length)
* past_key_values = (batch_size, num_key_value_heads, 0, head_dim)
* present_key_values = (batch_size, num_key_value_heads, 0 + prompt_length, head_dim) = (batch_size, * num_key_value_heads, prompt_length, head_dim)

**Token generation (aka decode):**
* input_ids = (batch_size, 1)
* attn_mask = (batch_size, past_sequence_length + 1)
* pos_ids = (batch_size, 1)
* past_key_values = (batch_size, num_key_value_heads, past_sequence_length, head_dim)
* present_key_values = (batch_size, num_key_value_heads, past_sequence_length + 1, head_dim)